### PR TITLE
Appending GET parameters to a URL already containing GET parameters

### DIFF
--- a/src/src/providers/geteduroam-services/geteduroam-services.ts
+++ b/src/src/providers/geteduroam-services/geteduroam-services.ts
@@ -107,9 +107,14 @@ export class GeteduroamServices {
    * @param data: oAUthModel
    */
   async generateOAuthFlow(data: oAuthModel) {
-
-    let url = `${data.oAuthUrl}?client_id=${data.client_id}&response_type=${data.type}&redirect_uri=${data.redirectUrl}`
-        url += `&scope=${data.scope}&state=${CryptoUtil.generateRandomString(10)}`;
+    let url = data.oAuthUrl;
+    if (url.includes("?")) {
+		url += "&";
+	} else {
+		url += "?";
+    }
+    url += `client_id=${data.client_id}&response_type=${data.type}&redirect_uri=${data.redirectUrl}`
+    url += `&scope=${data.scope}&state=${CryptoUtil.generateRandomString(10)}`;
     let codeVerifier = CryptoUtil.generateRandomString(43);
     let codeChallenge = await CryptoUtil.deriveChallenge(codeVerifier);
 


### PR DESCRIPTION
When appending the GET parameters to the authorize URL in the geteduroam flow, the client must check if the provided URL already contains a question mark `?`. If it does, it must not append another question mark but rather an ampersand `&`.