### PR TITLE
Longest common suffix should only be calculated for Android

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -27,7 +27,7 @@ npm-debug.log*
 /dist
 /node_modules
 /platforms
-/plugins
+/plugins/wifi-eap-configurator/node_modules
 /www
 /tsconfig.spec.json
 /documentation

--- a/src/plugins/wifi-eap-configurator/android/src/main/java/com/emergya/wifieapconfigurator/WifiEapConfigurator.java
+++ b/src/plugins/wifi-eap-configurator/android/src/main/java/com/emergya/wifieapconfigurator/WifiEapConfigurator.java
@@ -222,9 +222,8 @@ public class WifiEapConfigurator extends Plugin {
 
         if (servernames.length != 0 && servernames[0] != "") {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                String longestCommonSuffix = null;
-                if (call.getString("longestCommonSuffix") != null && !call.getString("longestCommonSuffix").trim().equals("")) {
-                    longestCommonSuffix = call.getString("longestCommonSuffix");
+                String longestCommonSuffix = getLongestSuffix(servernames);
+                if (longestCommonSuffix.length() > 0) {
                     enterpriseConfig.setDomainSuffixMatch(longestCommonSuffix);
                 } else {
                     enterpriseConfig.setDomainSuffixMatch(servernames[0]);
@@ -994,6 +993,27 @@ public class WifiEapConfigurator extends Plugin {
             e.printStackTrace();
         }
         return fingerprint;
+    }
+
+    private static String getLongestSuffix(String[] strings) {
+        if (strings.length == 0) return "";
+        if (strings.length == 1) return strings[0];
+        String longest = strings[0];
+        for(String candidate : strings) {
+            int pos = candidate.length();
+            do {
+                pos = candidate.lastIndexOf('.', pos - 2) + 1;
+            } while (pos > 0 && longest.endsWith(candidate.substring(pos)));
+            if (!longest.endsWith(candidate.substring(pos))) {
+                pos = candidate.indexOf('.', pos);
+            }
+            if (pos == -1) {
+                longest = "";
+            } else if (longest.endsWith(candidate.substring(pos))) {
+                longest = candidate.substring(pos == 0 ? 0 : pos + 1);
+            }
+        }
+        return longest;
     }
 
 }

--- a/src/plugins/wifi-eap-configurator/android/src/test/java/com/emergya/wifieapconfigurator/SuffixTest.java
+++ b/src/plugins/wifi-eap-configurator/android/src/test/java/com/emergya/wifieapconfigurator/SuffixTest.java
@@ -1,0 +1,60 @@
+package com.emergya.wifieapconfigurator;
+
+import junit.framework.TestCase;
+
+public class SuffixTest extends TestCase {
+	static private <T> void revert(T[] array) {
+		for(int i=0; i<array.length/2; i++){
+			T temp = array[i];
+			array[i] = array[array.length -i -1];
+			array[array.length -i -1] = temp;
+		}
+	}
+	
+	private static void testSuffix(String expected, String[] actual) {
+		assertEquals(expected, WifiEapConfigurator.getLongestSuffix(actual));
+		revert(actual);
+		assertEquals(expected, WifiEapConfigurator.getLongestSuffix(actual));
+	}
+	
+	public void testZero() {
+		testSuffix("", 
+				new String[0]
+			);
+	}
+	public void testOne() {
+		testSuffix("example.com", 
+				new String[] {"example.com"}
+			);
+	}
+	public void testZeroSegment() {
+		testSuffix("", 
+				new String[] {"junit.example.com", "junit.example.org"}
+			);
+	}
+	public void testOneSegment() {
+		testSuffix("com", 
+				new String[] {"junit.example.com", "junit.java.com"}
+			);
+	}
+	public void testTwoSegment() {
+		testSuffix("example.com", 
+				new String[] {"junit.example.com", "else.example.com"}
+			);
+	}
+	public void testEmptySegment() {
+		testSuffix("", 
+				new String[] {"example.com", ""}
+			);
+	}
+	public void testDifferentSegmentLength() {
+		testSuffix("com", 
+				new String[] {"example.com", "com"}
+			);
+	}
+	public void testOddOneOut() {
+		testSuffix("", 
+				new String[] {"sub.example.com", "sub.example.org", "sub.example.com", "sub.example.com"}
+			);
+	}
+}

--- a/src/src/pages/profile/profile.ts
+++ b/src/src/pages/profile/profile.ts
@@ -300,33 +300,7 @@ export class ProfilePage extends BasePage{
       auth: this.global.auth.MSCHAPv2,
       anonymous: "",
       caCertificate: this.validMethod.serverSideCredential.ca,
-      longestCommonSuffix: this.longestCommonSuffix(this.validMethod.serverSideCredential.serverID)
     };
-  }
-
-  private longestCommonSuffix(input){
-    let array = input.map(function(e) {
-      e = e.split("").reverse().join("");
-      return e;
-    });
-    let sortedArray = array.sort();
-    let first = sortedArray[0];
-    let last = sortedArray.pop();
-    let length = first.length;
-    let index = 0;
-    while(index<length && first[index] === last[index])
-      index++;
-    let candidate = first.substring(0, index).split("").reverse().join("");
-    if (!input.includes(candidate)) { // if this happens it is because is a common suffix
-      let parts = candidate.split('.');
-      if (parts.length > 2) {
-        parts.shift(); // removing the first one
-        candidate = parts.join('.');
-      } else {
-        candidate = '';
-      }
-    }
-    return candidate;
   }
 
   goBack() {


### PR DESCRIPTION
When setting up a profile in Android, a "Domain name" must be chosen. This is used as a suffix check on the certificate that is presented. The app will currently list all valid certificate names in the eap-config file and calculate the longest common suffix that matches all of these, but it does so in the common section, while the prefix is only needed for Android.

This PR moves the Android-specific code to the Java part of the app, and adds a test for this. Additionally, the /src/plugins directory was ignored through .gitignore but there is code in this directory, which is why I removed it from .gitignore.

Please note that I have not tested this PR, but I have tested the Java code (JUnit test included).