### PR TITLE
Use provided constants instead of magic numbers

### DIFF
--- a/src/plugins/wifi-eap-configurator/ios/Plugin/Plugin.swift
+++ b/src/plugins/wifi-eap-configurator/ios/Plugin/Plugin.swift
@@ -199,14 +199,14 @@ public class WifiEapConfigurator: CAPPlugin {
         let config = NEHotspotConfiguration(ssid: ssid, eapSettings: eapSettings)
         NEHotspotConfigurationManager.shared.apply(config) { (error) in
             if let error = error {
-                if error.code == 13 {
+                if error.code == NEHotspotConfigurationError.alreadyAssociated /* 13 */ {
                     call.success([
                         "message": "plugin.wifieapconfigurator.error.network.alreadyAssociated",
                         "success": false,
                     ])
                 }
                 
-                if error.code == 7 {
+                if error.code == NEHotspotConfigurationError.userDenied /* 7 */ {
                     call.success([
                         "message": "plugin.wifieapconfigurator.error.network.userCancelled",
                         "success": false,


### PR DESCRIPTION
The code uses magic numbers, it would be better to use the constants from the API