### PR TITLE
Outer identity is not respected

### DIFF
--- a/src/src/pages/profile/profile.ts
+++ b/src/src/pages/profile/profile.ts
@@ -298,7 +298,7 @@ export class ProfilePage extends BasePage{
       eap: parseInt(this.validMethod.eapMethod.type.toString()),
       servername: this.validMethod.serverSideCredential.serverID,
       auth: this.global.auth.MSCHAPv2,
-      anonymous: "",
+      anonymous: this.validMethod.clientSideCredential.anonymousIdentity,
       caCertificate: this.validMethod.serverSideCredential.ca,
     };
   }


### PR DESCRIPTION
When setting `<OuterIdentity>anonymous@example.com</OuterIdentity>` in the eap-config data, clients will still use the common name of the certificate as their outer ("anonymous") identity. ~~This bug is not present in Android, which uses the correct outer identity.~~