### PR TITLE
Show "please wait" screen while configuring

### DIFF
--- a/src/resources/dictionaries/en.json
+++ b/src/resources/dictionaries/en.json
@@ -48,7 +48,8 @@
     "configure": "Continue to configure ",
     "reconfigure1": "Hi, It seems you have ",
     "reconfigure2": " configured on your device.\n Do you want to reconfigure it?",
-    "network-available": "External access available"
+    "network-available": "External access available",
+    "configuring": "We are configuring your device, please wait"
   },
   "defaultError": "Key not found"
 }

--- a/src/resources/dictionaries/es.json
+++ b/src/resources/dictionaries/es.json
@@ -49,7 +49,8 @@
     "configure" : "Continuar para configurar ",
     "reconfigure1": "Hola, Parece que tienes ",
     "reconfigure2":" configurada en tu dispositivo.\n ¿Quieres volver a configurarla?",
-    "network-available": "Acceso remoto disponible"
+    "network-available": "Acceso remoto disponible",
+    "configuring": "Estamos configurando su dispositivo, espera porfavor"
   },
   "defaultError": "Clave no encontrada"
 }

--- a/src/src/pages/oauthFlow/oauthFlow.html
+++ b/src/src/pages/oauthFlow/oauthFlow.html
@@ -1,14 +1,9 @@
 <div *ngIf="showAll" class="container-content">
     <div class="header-content" margin-top padding-top>
         <img alt="setting" src="../../assets/icon/cog-outline.svg" />
-        <h1>{{getString('header', 'config')}}</h1>
     </div>
 
-    <div class="content-form" margin-top padding-top text-center></div>
-
-    <div class="footer-form" text-center>
-        <div class="content-button">
-            <button (click)="navigateTo()" class="button-control" ion-button text-capitalize> {{getString('button', 'next')}} </button>
-        </div>
+    <div class="content-form" margin-top padding-top text-center>
+        {{getString('text', 'configuring')}}
     </div>
 </div>

--- a/src/src/pages/oauthFlow/oauthFlow.scss
+++ b/src/src/pages/oauthFlow/oauthFlow.scss
@@ -1,3 +1,7 @@
 page-oauthFlow {
-
+  .content-form{
+    font-size: 130%;
+    margin-left: 10%;
+    margin-right: 10%;
+  }
 }

--- a/src/src/pages/oauthFlow/oauthFlow.ts
+++ b/src/src/pages/oauthFlow/oauthFlow.ts
@@ -96,6 +96,7 @@ export class OauthFlow extends BasePage{
     this.loading.create();
     if (!!error) {
       this.errorHandler.handleError(this.dictionary.getTranslation('error', 'invalid-oauth'), false, '', '', true);
+      this.navCtrl.pop();
     }
     this.loading.dismiss();
   }


### PR DESCRIPTION
The app can show a screen with a Next button while eduroam is being configured. This is confusing for the user, because they might expect that they need to do something.

It seems the button is displayed after configuring OAuth but not after configuring with username/password. Pressing the button shows an exception, even though eduroam configuration still works.

It would be better to show a "please wait" screen while configuring occurs.