### PR TITLE
Done button in institute search only clears the search string

### DIFF
--- a/src/src/pages/institutionSearch/institutionSearch.html
+++ b/src/src/pages/institutionSearch/institutionSearch.html
@@ -1,11 +1,5 @@
 <ion-header transparent>
-    <ion-toolbar *ngIf="ios">
-        <ion-searchbar #searchBar (ionCancel)="clearInstance()" (ionInput)="getItems($event)"
-                       [(ngModel)]="instanceName" placeholder="{{getString('placeholder', 'institution')}}"
-                       [showCancelButton]="true" cancelButtonText="{{getString('button', 'done')}}"></ion-searchbar>
-    </ion-toolbar>
-
-    <ion-toolbar *ngIf="!ios">
+    <ion-toolbar>
         <ion-searchbar #searchBar (ionCancel)="clearInstance()" (ionInput)="getItems($event)"
                        [(ngModel)]="instanceName" placeholder="{{getString('placeholder', 'institution')}}"></ion-searchbar>
     </ion-toolbar>


### PR DESCRIPTION
When using the institute search in the iOS app, there is a "Done" button but the function of this button is not clear, because pressing the name of an institution will close the list.

![Institute search](https://user-images.githubusercontent.com/767872/76531654-d2465f80-6475-11ea-91d1-81c12cdf465a.jpeg)

This is especially confusing if the users searched for a non-existing institute.

![IMG_E8C191FCA48E-1](https://user-images.githubusercontent.com/767872/76532035-5a2c6980-6476-11ea-830f-771f0639d1f7.jpeg)