### PR TITLE
Faster discovery by not loading/unloading keyboard

### DIFF
--- a/src/src/pages/configScreen/configScreen.html
+++ b/src/src/pages/configScreen/configScreen.html
@@ -16,7 +16,7 @@
 
         <div *ngIf="this.instances" class="row" padding-top>
 
-            <ion-searchbar (click)="showModal($event)" [(ngModel)]="instanceName" cancelButtonText debounce="500"
+            <ion-searchbar #instituteSearchBar (click)="searchBarClicked($event)" [(ngModel)]="instanceName" cancelButtonText debounce="500"
                            class="searchbar-input" no-padding placeholder="{{getString('placeholder', 'institution')}}">
 
             </ion-searchbar>

--- a/src/src/pages/institutionSearch/institutionSearch.html
+++ b/src/src/pages/institutionSearch/institutionSearch.html
@@ -1,6 +1,6 @@
 <ion-header transparent>
     <ion-toolbar>
-        <ion-searchbar #searchBar (ionCancel)="clearInstance()" (ionInput)="getItems($event)"
+        <ion-searchbar #instituteSearchBar (ionCancel)="clearInstance()" (ionInput)="getItems($event)" debounce="100"
                        [(ngModel)]="instanceName" placeholder="{{getString('placeholder', 'institution')}}"></ion-searchbar>
     </ion-toolbar>
 </ion-header>

--- a/src/src/pages/institutionSearch/institutionSearch.ts
+++ b/src/src/pages/institutionSearch/institutionSearch.ts
@@ -16,12 +16,12 @@ export class InstitutionSearch extends BasePage{
   /**
    * Institutions
    */
-  instances: any;
+  instances: any[];
 
   /**
    * Set of institutions filtered by what is written in the search-bar
    */
-  filteredInstances: any;
+  filteredInstances: any[];
 
   /**
    * Name of the selected profile
@@ -51,7 +51,7 @@ export class InstitutionSearch extends BasePage{
   /**
    * Component SearchBar
    */
-  @ViewChild('searchBar') searchBar: Searchbar;
+  @ViewChild('instituteSearchBar') instituteSearchBar: Searchbar;
 
   constructor(public navParams: NavParams, private viewCtrl: ViewController,
               private platform: Platform, protected loading: LoadingProvider,
@@ -68,9 +68,9 @@ export class InstitutionSearch extends BasePage{
    * This method also calls the methods [initializeProfiles()]{@link #initializeProfiles} and [checkProfiles()]{@link #checkProfiles}.
    * @param {any} institution the selected institution.
    */
-  selectInstitution(institution: any) {
+  selectInstitution(institution: any[]) {
     this.instances = institution;
-    this.searchBar.setFocus();
+    this.instituteSearchBar.setFocus();
     this.viewCtrl.dismiss(institution);
   }
 
@@ -146,7 +146,7 @@ export class InstitutionSearch extends BasePage{
   }
   ionViewDidEnter() {
     setTimeout(() => {
-      this.searchBar.setFocus()
+      this.instituteSearchBar.setFocus()
     }, 10);
     if (!this.ios) {
       Keyboard.show();


### PR DESCRIPTION
The button with the search glass is actually a text input;
pressing it will place a cursor and open a keyboard. This keyboard is then hidden rightaway.
Loading/unloading the keyboard takes a long time especially on Android phones,
which makes the already slow process of loading the discovery list even slower.

By marking the inner input field as readOnly, the OS knows you don't need a keyboard and won't show one.