### PR TITLE
Configuring eduroam when a CAT mobileconfig profile is already installed

### DIFF
--- a/src/plugins/wifi-eap-configurator/ios/Plugin/Plugin.swift
+++ b/src/plugins/wifi-eap-configurator/ios/Plugin/Plugin.swift
@@ -234,6 +234,10 @@ public class WifiEapConfigurator: CAPPlugin {
 				// Are you running in an emulator?
 				errors.append("plugin.wifieapconfigurator.error.network.internal")
 				break
+			case NEHotspotConfigurationError.systemConfiguration.rawValue:
+				// There is a conflicting mobileconfig installed
+				errors.append("plugin.wifieapconfigurator.error.network.mobileconfig")
+				break
 			default:
 				errors.append("plugin.wifieapconfigurator.error.network.other." + String(error!.code))
 			}

--- a/src/resources/dictionaries/en.json
+++ b/src/resources/dictionaries/en.json
@@ -36,6 +36,7 @@
     "password": "Password is incorrect",
     "turn-on": "Please, turn on mobile data",
     "duplicate": "This network is already available in the device.\nPlease go to Settings > Wi-Fi Networks and remove it first",
+    "mobileconfig": "Your device is configured through a configuration profile.\nPlease go to Settings > General > Profile and remove it",
     "invalid-eap": "Invalid selected profile, if the error persists, contact with the admin please",
     "invalid-method": "No valid authentication method available from the selected profile",
     "invalid-profile": "The selected profile is wrong",

--- a/src/src/pages/profile/profile.ts
+++ b/src/src/pages/profile/profile.ts
@@ -131,6 +131,9 @@ export class ProfilePage extends BasePage{
       }else if (checkRequest.message.includes('error.network.alreadyAssociated')) {
         await this.errorHandler.handleError(
             this.dictionary.getTranslation('error', 'duplicate'), false, '', '', true);
+      }else if (checkRequest.message.includes('error.network.mobileconfig')) {
+        await this.errorHandler.handleError(
+            this.dictionary.getTranslation('error', 'mobileconfig'), false, '', '', true);
       } else if (checkRequest.message.includes('error.network.userCancelled')) {
         this.showAll = true;
       } else {

--- a/src/src/providers/oauth-conf/oauth-conf.ts
+++ b/src/src/providers/oauth-conf/oauth-conf.ts
@@ -55,6 +55,9 @@ export class OauthConfProvider {
     }else if (checkRequest.message.includes('error.network.alreadyAssociated')) {
       await this.errorHandler.handleError(
           this.dictionary.getTranslation('error', 'duplicate'), false, '', '', true);
+    }else if (checkRequest.message.includes('error.network.mobileconfig')) {
+      await this.errorHandler.handleError(
+          this.dictionary.getTranslation('error', 'mobileconfig'), false, '', '', true);
     } else if (checkRequest.message.includes('error.network.userCancelled')) {
       await this.navCtrl.pop();
     } else {


### PR DESCRIPTION
When a mobileconfig from CAT is already installed, the geteduroam app seemingly succeeds, but it actually keeps the profile as-is but changes the password.

I tried this by installing the Uninett profile from CAT, then installing eVA through geteduroam. The result was connecting to eduroam failing, and after a while it asked for my password, with my Uninett username prefilled (not eVA). When I entered my Uninett password, the connection succeeded.

I then tried the same thing again, I chose eVA in geteduroam, but this time I entered my eVA username and Uninett password. This caused the iPhone to succesfully authenticate with my Uninett account.

When I try to set a geteduroam profile, it also seemingly succeeds, but still uses my old credentials afterwards.

It seems like geteduroam sets the user-entered password in the profile, but fails to set the other settings, and it fails silently.