### PR TITLE
Handle discovery failing to load

### DIFF
--- a/src/resources/dictionaries/en.json
+++ b/src/resources/dictionaries/en.json
@@ -62,7 +62,8 @@
     "configure": "Continue configuring",
     "reconfigure": "Hi, It seems you have configured this device already.\nDo you want to reconfigure it?",
     "network-available": "External access available",
-    "configuring": "We are configuring your device, please wait"
+    "configuring": "We are configuring your device, please wait",
+    "institutions": "Loading institutions"
   },
   "defaultError": "Key not found"
 }

--- a/src/resources/dictionaries/es.json
+++ b/src/resources/dictionaries/es.json
@@ -62,7 +62,8 @@
     "configure" : "Continuar para configurar eduroam",
     "reconfigure": "Hola, Parece que tienes eduroam configurada en tu dispositivo.\n¿Quieres volver a configurarla?",
     "network-available": "Acceso remoto disponible",
-    "configuring": "Estamos configurando su dispositivo, espera porfavor"
+    "configuring": "Estamos configurando su dispositivo, espera porfavor",
+    "institutions": "Cargando instituciones"
   },
   "defaultError": "Clave no encontrada"
 }

--- a/src/src/pages/basePage.ts
+++ b/src/src/pages/basePage.ts
@@ -135,10 +135,10 @@ export abstract class BasePage {
 
     let terms = splitTerms.map(res => {
       if (!!res.match(/\bwww?\S+/gi) ||  !!res.match(/\bhttps?\S+/gi) || res.match(/\bhttp?\S+/gi)) {
-        res = !!res.match(/\bwww?\S+/gi) ? 'http://'+res.match(/\bwww?\S+/gi)[0] :
+        const link = !!res.match(/\bwww?\S+/gi) ? 'http://'+res.match(/\bwww?\S+/gi)[0] :
           !!res.match(/\bhttps?\S+/gi) ? res.match(/\bhttps?\S+/gi)[0] : res.match(/\bhttp?\S+/gi)[0];
 
-        res =`<a href="${res}">${res}</a>`;
+        res =`<a href="${link}">${res}</a>`;
 
       }
       return res
@@ -157,7 +157,7 @@ export abstract class BasePage {
       ${terms}`;
     const pageContentUrl = 'data:text/html;base64,' + btoa(htmlView);
     const browser = window.cordova.InAppBrowser.open(
-      pageContentUrl ,
+      pageContentUrl,
       '_blank',
       'location=no,hidenavigationbuttons=yes,hidespinner=yes,toolbarposition=top,beforeload=yes'
     );
@@ -166,7 +166,7 @@ export abstract class BasePage {
       if (params.url == pageContentUrl) {
         callback(params.url);
       } else {
-        window.cordova.InAppBrowser.open(params.url, '_system');
+        Browser.open({url: params.url});
         setTimeout(() => browser.close(), 1000);
       }
     });

--- a/src/src/pages/configScreen/configScreen.html
+++ b/src/src/pages/configScreen/configScreen.html
@@ -14,7 +14,7 @@
     <div class="content-form" margin-top padding-top text-center>
         <ion-label class="label-conf" no-margin padding-top text-left>{{getString('label', 'institution')}}</ion-label>
 
-        <div *ngIf="this.institutions" class="row" padding-top>
+        <div *ngIf="institutions" class="row" padding-top>
 
             <ion-searchbar #instituteSearchBar (click)="searchBarClicked($event)" [(ngModel)]="institutionName" cancelButtonText debounce="500"
                            class="searchbar-input" no-padding placeholder="{{getString('placeholder', 'institution')}}">

--- a/src/src/pages/configScreen/configScreen.ts
+++ b/src/src/pages/configScreen/configScreen.ts
@@ -92,7 +92,6 @@ export class ConfigurationScreen extends BasePage{
               protected dictionary: DictionaryServiceProvider, protected global: GlobalProvider,
               private errorHandler: ErrorHandlerProvider) {
     super(loading, dictionary, event, global);
-
   }
 
   /**
@@ -233,10 +232,8 @@ export class ConfigurationScreen extends BasePage{
   }
 
   async ngOnInit() {
-    this.event.subscribe('connection',  () => {
-      this.chargeDiscovery()
-      if (!!this.global.isAndroid()) this.showToast(this.getString('text', 'institutions'));
-    });
+   this.suscribeEvent()
+    this.institutions = this.global.discovery;
   }
 
   async ionViewWillEnter() {
@@ -325,4 +322,10 @@ export class ConfigurationScreen extends BasePage{
     }
   }
 
+  suscribeEvent() {
+    this.event.subscribe('connection',  () => {
+      this.chargeDiscovery()
+      if (!!this.global.isAndroid()) this.showToast(this.getString('text', 'institutions'));
+    });
+  }
 }

--- a/src/src/pages/configScreen/configScreen.ts
+++ b/src/src/pages/configScreen/configScreen.ts
@@ -232,7 +232,7 @@ export class ConfigurationScreen extends BasePage{
   }
 
   async ngOnInit() {
-   this.suscribeEvent()
+    this.event.subscribe('connection', () => this.institutions.length === 0 && this.chargeDiscovery());
     this.institutions = this.global.discovery;
   }
 
@@ -320,12 +320,5 @@ export class ConfigurationScreen extends BasePage{
     } else {
       this.navCtrl.push(ConfigFilePage, '', {animation: 'transition'});
     }
-  }
-
-  suscribeEvent() {
-    this.event.subscribe('connection',  () => {
-      this.chargeDiscovery()
-      if (!!this.global.isAndroid()) this.showToast(this.getString('text', 'institutions'));
-    });
   }
 }

--- a/src/src/pages/configScreen/configScreen.ts
+++ b/src/src/pages/configScreen/configScreen.ts
@@ -93,11 +93,6 @@ export class ConfigurationScreen extends BasePage{
               private errorHandler: ErrorHandlerProvider) {
     super(loading, dictionary, event, global);
 
-    this.event.subscribe('connection', async (res: any) => {
-      if (!!res.connected && !this.global.discovery) {
-        await this.chargeDiscovery()
-      }
-    });
   }
 
   /**
@@ -238,7 +233,10 @@ export class ConfigurationScreen extends BasePage{
   }
 
   async ngOnInit() {
-    this.institutions = this.global.discovery;
+    this.event.subscribe('connection',  () => {
+      this.chargeDiscovery()
+      if (!!this.global.isAndroid()) this.showToast(this.getString('text', 'institutions'));
+    });
   }
 
   async ionViewWillEnter() {


### PR DESCRIPTION
When the discovery fails to load due to a bad internet connection, the app will finally show an error message informing the user of a timeout. After the user presses Back, the normal Institution selection page is shown, but pressing the search button doesn't do anything.

This error needs better handling. While downloading the institution file, the user should see some information about why loading takes such a long time, and when it fails the app should try again.