### PR TITLE
Improve handling of Terms of Use

### DIFF
--- a/geteduroam/src/pages/basePage.ts
+++ b/geteduroam/src/pages/basePage.ts
@@ -135,31 +135,26 @@ export abstract class BasePage {
 
     // Remove BOM
     termsOfUse = termsOfUse.replace(/^\uFEFF/gm, "").replace(/^\u00BB\u00BF/gm,"");
-    
-    // Unreliable HTML check, we see if we have any < after a whitespace, or start of string
-    let fixLinks = !termsOfUse.match(/(^|\s)<a[\S\t ]*>/); // Do we have any <a …>
-    let fixNewlines = !termsOfUse.match(/(^|\s)<(p|br)[\S\t ]*>/); // Do we have any <br> or <p>
 
-    if (fixNewlines) {
-      // Replace every double newline with <p> and every single newline with <br>
-      termsOfUse = termsOfUse
-        .replace(/([\t ]*\r?\n){2,}/g, ' <p>')
-        .replace(/([\t ]*\r?\n)/g, ' <br>');
-    }
+    // Escape HTML
+    termsOfUse = termsOfUse.replace("<", "&lt;").replace(">", "&rt;").replace("\"", "&quot;");
 
-    if (fixLinks) {
-      // Split on space (so we can check per word if it is a link)
-      termsOfUse = termsOfUse.split(/\s+/g).map(res => {
-        if (!!res.match(/\bwww?\S+/gi) || !!res.match(/\bhttps?\S+/gi) || res.match(/\bhttp?\S+/gi)) {
-          const link = !!res.match(/\bwww?\S+/gi) ? 'http://'+res.match(/\bwww?\S+/gi)[0] :
-            !!res.match(/\bhttps?\S+/gi) ? res.match(/\bhttps?\S+/gi)[0] : res.match(/\bhttp?\S+/gi)[0];
+    // Replace every double newline with <p> and every single newline with <br>
+    termsOfUse = termsOfUse
+      .replace(/([\t ]*\r?\n){2,}/g, ' <p>')
+      .replace(/([\t ]*\r?\n)/g, ' <br>');
 
-          res =`<a href="${link}">${res}</a>`;
+    // Split on space (so we can check per word if it is a link)
+    termsOfUse = termsOfUse.split(/\s+/g).map(res => {
+      if (!!res.match(/\bwww\.?\S+/gi) || !!res.match(/\bhttps:\/\/?\S+/gi) || res.match(/\bhttp:\/\/?\S+/gi)) {
+        const link = !!res.match(/\bwww?\S+/gi) ? 'http://'+res.match(/\bwww?\S+/gi)[0] :
+          !!res.match(/\bhttps?\S+/gi) ? res.match(/\bhttps?\S+/gi)[0] : res.match(/\bhttp?\S+/gi)[0];
 
-        }
-        return res
-      }).join(' ');
-    }
+        res =`<a href="${link}">${res}</a>`;
+
+      }
+      return res
+    }).join(' ');
 
     const htmlView = `<title>${this.getString('label', 'terms')}</title>
       <meta name="charset" value="utf-8">

--- a/geteduroam/src/pages/clientCertificatePassphrase/clientCertificatePassphrase.ts
+++ b/geteduroam/src/pages/clientCertificatePassphrase/clientCertificatePassphrase.ts
@@ -69,10 +69,6 @@ export class ClientCertificatePassphrasePage extends BasePage{
    * Check help desk
    */
   helpDesk: boolean = false;
-  /**
-   * Link url of terms of use
-   */
-  termsUrl: string = '';
 
   constructor(public navCtrl: NavController, public navParams: NavParams, protected event: Events,
               public loading: LoadingProvider, public dictionary: DictionaryServiceProvider,
@@ -91,7 +87,7 @@ export class ClientCertificatePassphrasePage extends BasePage{
 
   ionViewDidEnter() {
     this.providerInfo = this.global.getProviderInfo();
-    if (!!this.providerInfo.termsOfUse) this.createTerms();
+    this.termsOfUse = !!this.providerInfo.termsOfUse;
     if (!!this.providerInfo.helpdesk.emailAddress || !!this.providerInfo.helpdesk.webAddress ||
         !!this.providerInfo.helpdesk.phone) this.helpDesk = true;
     if (typeof this.global.getAuthenticationMethod().clientSideCredential.passphrase !== 'undefined') {
@@ -143,20 +139,6 @@ export class ClientCertificatePassphrasePage extends BasePage{
     const data = `data:${mimeType};${encoding},${imageData}`;
 
     this.converted_image = this.sanitizer.bypassSecurityTrustResourceUrl(data);
-  }
-
-  protected createTerms() {
-    // Activate checkbox on view
-    this.termsOfUse = true;
-    const terms = this.providerInfo.termsOfUse.toString();
-    try {
-      // Get the web address within the terms of use
-      this.termsUrl = !!terms.match(/\bwww?\S+/gi) ? 'http://'+terms.match(/\bwww?\S+/gi)[0] :
-          !!terms.match(/\bhttps?\S+/gi) ? terms.match(/\bhttps?\S+/gi)[0] : terms.match(/\bhttp?\S+/gi)[0];
-    } catch (e) {
-      this.termsOfUse = false;
-    }
-
   }
 
 }

--- a/geteduroam/src/pages/profile/profile.ts
+++ b/geteduroam/src/pages/profile/profile.ts
@@ -294,7 +294,7 @@ export class ProfilePage extends BasePage{
       this.logo = true;
       this.getLogo();
     }
-    if (!!this.providerInfo.termsOfUse) this.createTerms();
+    this.termsOfUse = !!this.providerInfo.termsOfUse;
     if (!!this.providerInfo.helpdesk.emailAddress || !!this.providerInfo.helpdesk.webAddress ||
         !!this.providerInfo.helpdesk.phone) this.helpDesk = true;
     if (this.validMethod.clientSideCredential.username && this.validMethod.clientSideCredential.password) {
@@ -306,23 +306,6 @@ export class ProfilePage extends BasePage{
       this.showForm = true;
     }
     this.showAll = true;
-  }
-
-  /**
-   * Method to activate terms of use on view.
-   */
-  protected createTerms() {
-      // Activate checkbox on view
-      this.termsOfUse = true;
-      const terms = this.providerInfo.termsOfUse.toString();
-      try {
-        // Get the web address within the terms of use
-        this.termsUrl = !!terms.match(/\bwww?\S+/gi) ? 'http://'+terms.match(/\bwww?\S+/gi)[0] :
-          !!terms.match(/\bhttps?\S+/gi) ? terms.match(/\bhttps?\S+/gi)[0] : terms.match(/\bhttp?\S+/gi)[0];
-      } catch (e) {
-        this.termsOfUse = false;
-      }
-
   }
 
   /**


### PR DESCRIPTION
Remove old code that checked if the ToU contains a link; earlier iterations of the app assumed that the ToU was ONLY a link, but that's not how it's supposed to work.

Update the viewer to support UTF-8, only ASCII was supported earlier.

Handle newlines in the ToU text by replacing single newlines with `<br>` and multiple newlines with `<p>`.