### PR TITLE
Convert OIDs to uppercase

### DIFF
--- a/geteduroam/plugins/wifi-eap-configurator/ios/Plugin/Plugin.swift
+++ b/geteduroam/plugins/wifi-eap-configurator/ios/Plugin/Plugin.swift
@@ -224,7 +224,7 @@ public class WifiEapConfigurator: CAPPlugin {
 				let hs20 = NEHotspotHS20Settings(
 					domainName: domain,
 					roamingEnabled: true)
-				hs20.roamingConsortiumOIs = oids;
+				hs20.roamingConsortiumOIs = oids.map { $0.uppercased() };
 				configurations.append(NEHotspotConfiguration(hs20Settings: hs20, eapSettings: eapSettings))
 			}
 		}


### PR DESCRIPTION
It appears that iOS requires OIDs to be upper case when writing configuration, or it won't try to connect to the accesspoint.

Thanks @farhansj for researching this!