### PR TITLE
Add an alternative identifier for CA when it doesn't have a CN

### DIFF
--- a/geteduroam/plugins/wifi-eap-configurator/ios/Plugin/Plugin.swift
+++ b/geteduroam/plugins/wifi-eap-configurator/ios/Plugin/Plugin.swift
@@ -537,7 +537,12 @@ public class WifiEapConfigurator: CAPPlugin {
 		}
 
 		let rawSubject = SecCertificateCopyNormalizedSubjectSequence(certificateRef)
-		let certificateIdentifier: String = (rawSubject as! Data).base64EncodedString(options: Data.Base64EncodingOptions())
+		guard rawSubject != nil else {
+			// When does this happen?
+			NSLog("☠️ addCertificate: unable to get certificate subject")
+			return nil
+		}
+		let certificateIdentifier: String = (rawSubject! as Data).base64EncodedString(options: Data.Base64EncodingOptions())
 		
 		let addquery: [String: Any] = [
 			kSecClass as String: kSecClassCertificate,


### PR DESCRIPTION
The GoDaddy CA does not have a CN it seems, and the app fails to import the certificate as a result of that.

Use a Base64 encoded binary representation of the subject instead; that should be at least as unique as the CN